### PR TITLE
Fix names of ©, ®, and ™ in code sample comment

### DIFF
--- a/README.md
+++ b/README.md
@@ -238,9 +238,9 @@ To exclude certain characters from being replaced by twemoji.js, call twemoji.pa
 twemoji.parse(document.body, {
     callback: function(icon, options, variant) {
         switch ( icon ) {
-            case 'a9':      // copyright  ©
-            case 'ae':      // trademark  ®
-            case '2122':    // team       ™
+            case 'a9':      // © copyright
+            case 'ae':      // ® registered trademark
+            case '2122':    // ™ trademark
                 return false;
         }
         return ''.concat(options.base, options.size, '/', icon, options.ext);


### PR DESCRIPTION
™ doesn't really stand for "team", and ® is a specific type of
trademark. It's the small things.

© http://en.wikipedia.org/wiki/Copyright_symbol
® http://en.wikipedia.org/wiki/Registered_trademark_symbol
™ http://en.wikipedia.org/wiki/Trademark_symbol
