### PR TITLE
Validate the first argument of parse method

### DIFF
--- a/2/twemoji.js
+++ b/2/twemoji.js
@@ -515,6 +515,14 @@ var twemoji = (function (
   }
 
   function parse(what, how) {
+    // first argument can only be string or HTML Element
+    if (
+      typeof what !== 'string' &&
+      !(what && what.nodeName)
+    ) {
+      return what;
+    }
+    
     if (!how || typeof how === 'function') {
       how = {callback: how};
     }


### PR DESCRIPTION
The first argument type of `parse` method can only be of `String` or `HTML Element`.