### PR TITLE
Add Twitter Color Emoji font to Community Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -346,6 +346,7 @@ However, we consider the guide a bit onerous and as a project, will accept a men
 * [FrwTwemoji - Twemoji in dotnet](https://github.com/FrenchW/FrwTwemoji) by [@FrenchW](https://twitter.com/frenchw): Use Twemoji in any dotnet project (C#, asp.net ...).
 * [Emojiawesome - Twemoji for Yellow](https://github.com/datenstrom/yellow-plugins/tree/master/emojiawesome) by [@datenstrom](https://github.com/datenstrom/): Use Twemoji in Yellow CMS.
 * [EmojiPanel for Twitter](https://github.com/danbovey/EmojiPanel) by [@danielbovey](https://twitter.com/danielbovey/status/749580050274582528): Insert Twemoji into your tweets on twitter.com.
+* [Twitter Color Emoji font](https://github.com/eosrei/twemoji-color-font) by [@bderickson](https://twitter.com/bderickson): Use Twemoji as your system default font on Linux & OS X.
 
 ## Committers and Contributors
 * Tom Wuttke (Twitter)


### PR DESCRIPTION
Thanks for making this emoji set. I've made a regular system TTF color font using these graphics.

https://github.com/eosrei/twemoji-color-font

Currently only available with the SVGinOT(Firefox/Adobe) OpenType color format, but I plan to add SBIX (OSX specific) and CBLC/CBDT (Android specific) versions in the future. There packages for Linux Ubuntu(PPA), Arch(AUR), Gentoo, and OS X(homebrew).