### PR TITLE
Fix npmignore for including emoji source files

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -22,3 +22,4 @@ svg.sh
 test.*
 test*
 twemoji*
+!2/twemoji*


### PR DESCRIPTION
After installing the new 2.2.4 version with yarn. emoji js source file still missing. This was due I think to the npmignore file