### PR TITLE
Update twemoji-generator.js for Emoji 5.0

### DIFF
--- a/twemoji-generator.js
+++ b/twemoji-generator.js
@@ -141,9 +141,9 @@ Queue([
   // grab the list of emoji that behave differently when
   // variants such \uFE0E and \uFE0F are in place
   function grabStandardVariants(q) {
-    console.log('fetching StandardizedVariants.txt ... ');
+    console.log('fetching emoji-variation-sequences.txt ... ');
     http.get(
-      "http://unicode.org/Public/UNIDATA/StandardizedVariants.txt",
+      "http://unicode.org/Public/emoji/latest/emoji-variation-sequences.txt",
       function(res) {
         var chunks = [];
         if (res.statusCode == 200) {


### PR DESCRIPTION
Emoji VS15/16 sequences have been moved from [`StandardizedVariants.txt`](http://unicode.org/Public/UNIDATA/StandardizedVariants.txt) to [`emoji-variation-sequences.txt`](http://unicode.org/Public/emoji/latest/emoji-variation-sequences.txt) with Unicode Emoji 5.0 / Unicode 10.0 (works already). File format is the same.