### PR TITLE
Add support for custom emoji template

### DIFF
--- a/twemoji.js
+++ b/twemoji.js
@@ -37,6 +37,9 @@ var twemoji = (function (
       // default class name, by default 'emoji'
       className: 'emoji',
 
+      // template function for custom emoji wrapping
+      template: null,
+
       // basic utilities / helpers to convert code points
       // to JavaScript surrogates and vice versa
       convert: {
@@ -482,6 +485,9 @@ var twemoji = (function (
             }
           }
           ret = ret.concat('>');
+          if (options.template) {
+            ret = options.template.call(null, ret)
+          }
         }
       }
       return ret;
@@ -551,6 +557,7 @@ var twemoji = (function (
       ext:        how.ext || twemoji.ext,
       size:       how.folder || toSizeSquaredAsset(how.size || twemoji.size),
       className:  how.className || twemoji.className,
+      template:   how.template || twemoji.template,
       onerror:    how.onerror || twemoji.onerror
     });
   }


### PR DESCRIPTION
Hi,

While using twemoji, we wanted to let user select parsed emojis like normal text, however, we are unable to achieve this by styling the img tag alone because we need:

- `pointer-event: none` to let user select image like normal text
- `cursor: text` to change cursor for UX

However `pointer-event: none` clashes with `cursor: text` on the same element, we needed to create a container that wraps the emoji element in order to achieve what we want.

We are creating this PR hoping twemoji could implement built in support for such functionality.

Usage with the new template option:

```es
twemoji.parse(htmlText, {
  template: (emoji) => {
    return `
      <div class="emoji-container">
        ${emoji}
      </div>
    `
  },
})
```