### PR TITLE
Update docs to point to 2.5.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The folks over at [MaxCDN](https://www.maxcdn.com) have graciously provided CDN 
 
 Use the following in the `<head>` tag of your HTML document(s):
 ```html
-<script src="//twemoji.maxcdn.com/2/twemoji.min.js?2.3.0"></script>
+<script src="//twemoji.maxcdn.com/2/twemoji.min.js?2.5.0"></script>
 ```
 
 ## Breaking changes in V2

--- a/index.html
+++ b/index.html
@@ -44,7 +44,7 @@
     <script async src="//platform.twitter.com/widgets.js" charset="utf-8"></script>
     
     <p>Code licensed under MIT. Graphics licensed under CC-BY</p>
-    <script src="https://twemoji.maxcdn.com/2/twemoji.min.js?2.3.0"></script>
+    <script src="https://twemoji.maxcdn.com/2/twemoji.min.js?2.5.0"></script>
     <script>
       // I \u2764 emoji!
       twemoji.parse(document.body);


### PR DESCRIPTION
This is just a small 2-line patch to upgrade mentions in the docs from 2.3.0 to 2.5.0.