### PR TITLE
expose emoji unicode regexp that is internally used for emoji parsing…

### DIFF
--- a/2/utils/generate
+++ b/2/utils/generate
@@ -502,6 +502,10 @@ function createTwemoji(re) {
 
       /*jshint maxparams:4 */
 
+      // RegExp based on emoji's official Unicode standards
+      // http://www.unicode.org/Public/UNIDATA/EmojiSources.txt
+      var re = /twemoji/;
+
       var
         // the exported module object
         twemoji = {
@@ -560,6 +564,9 @@ function createTwemoji(re) {
              */
             toCodePoint: toCodePoint
           },
+
+          // expose emoji unicode RegExp that is internally used for parsing (read only)
+          re: re,
 
 
         /////////////////////////
@@ -710,10 +717,6 @@ function createTwemoji(re) {
           "'": '&#39;',
           '"': '&quot;'
         },
-
-        // RegExp based on emoji's official Unicode standards
-        // http://www.unicode.org/Public/UNIDATA/EmojiSources.txt
-        re = /twemoji/,
 
         // avoid runtime RegExp creation for not so smart,
         // not JIT based, and old browsers / engines


### PR DESCRIPTION
expose emoji unicode regexp that is internally used for emoji parsing (read only)
This can be useful for advanced usage not to add extra package with emoji regexp, when it's already contained in and used in twemoji package.
Consider this example - I have extension for CodeMirror to replace emoji, but I have to know exactly where emoji were found in text and should be replaced with images for CodeMirror api. Of course I can parse string and then search for <img> tags, and then strip them to restore original positions, but it seems like overhead when all I need is regexp and it's already contained in library (just in private section).
```js
function CodeMirrorEmojione (cm) {
  return CodeMirrorReplace(cm, window.emojione.regUnicode,
                           window.emojione.unicodeToImage)
}

function CodeMirrorTwemoji (cm, options) {
  return CodeMirrorReplace(cm, window.twemoji.re,
                           text => window.twemoji.parse(text, options))
}

function CodeMirrorReplace (cm, regex, toHtml) {
  function createElement (text) {
    const html = toHtml(text)
    if (typeof html !== 'string') return html
    const span = document.createElement('span')
    span.innerHTML = html
    return span.firstChild
  }

  function replaceMatch ([line, ch, text]) {
    cm.markText(
      {line, ch},
      {line, ch: ch + text.length},
      {replacedWith: createElement(text)}
    )
  }

  function findMatches (fromLine, fromCh, lines) {
    const matches = []
    let match
    lines.forEach((line, lineIndex) => {
      // eslint-disable-next-line
      while (match = regex.exec(line)) {
        matches.push([
          fromLine + lineIndex,
          (lineIndex ? 0 : fromCh) + match.index,
          match[0],
        ])
      }
    })
    return matches
  }

  findMatches(0, 0, cm.getValue().split(cm.lineSeparator())).map(replaceMatch)
  cm.on('change', (cm_, change) => {
    findMatches(change.from.line, change.from.ch, change.text).map(replaceMatch)
  })
}
```
P.S. I didn't regenerate sources to make pull request looks more clean