### PR TITLE
Add Twemoji-Amazing as replacement for unmaintained Twemoji-Awesome to Community Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -332,8 +332,7 @@ As an open source project, attribution is critical from a legal, practical and m
 However, we consider the guide a bit onerous and as a project, will accept a mention in a project README or an 'About' section or footer on a website. In mobile applications, a common place would be in the Settings/About section (for example, see the mobile Twitter application Settings->About->Legal section). We would consider a mention in the HTML/JS source sufficient also.
 
 ## Community Projects
-
-* [Twemoji Awesome](http://ellekasai.github.io/twemoji-awesome/) by [@ellekasai](https://twitter.com/ellekasai/status/531979044036698112): Use Twemoji using CSS classes (like [Font Awesome](http://fortawesome.github.io/Font-Awesome/)).
+* [Twemoji Amazing](https://github.com/SebastianAigner/twemoji-amazing) by [@SebastianAigner](https://github.com/SebastianAigner): Use Twemoji using CSS classes (like [Font Awesome](http://fortawesome.github.io/Font-Awesome/)).
 * [Twemoji Ruby](https://github.com/jollygoodcode/twemoji) by [@JollyGoodCode](https://twitter.com/jollygoodcode): Use Twemoji in Ruby.
 * [Twemoji for Pencil](https://github.com/nathanielw/Twemoji-for-Pencil) by [@Nathanielnw](https://twitter.com/nathanielnw): Use Twemoji in Pencil.
 * [FrwTwemoji - Twemoji in dotnet](http://github.frenchw.net/FrwTwemoji/) by [@FrenchW](https://twitter.com/frenchw): Use Twemoji in any dotnet project (C#, asp.net ...).
@@ -341,6 +340,7 @@ However, we consider the guide a bit onerous and as a project, will accept a men
 * [EmojiPanel for Twitter](https://github.com/danbovey/EmojiPanel) by [@danielbovey](https://twitter.com/danielbovey/status/749580050274582528): Insert Twemoji into your tweets on twitter.com.
 * [Twitter Color Emoji font](https://github.com/eosrei/twemoji-color-font) by [@bderickson](https://twitter.com/bderickson): Use Twemoji as your system default font on Linux & OS X.
 * [Emojica](https://github.com/xoudini/emojica) by [@xoudini](https://twitter.com/xoudini): An iOS framework allowing you to replace all standard emoji in strings with Twemoji.
+* [Unmaintained] [Twemoji Awesome](http://ellekasai.github.io/twemoji-awesome/) by [@ellekasai](https://twitter.com/ellekasai/): Use Twemoji using CSS classes (like [Font Awesome](http://fortawesome.github.io/Font-Awesome/)).
 
 ## Committers and Contributors
 * Bryan Haggerty (Twitter)


### PR DESCRIPTION
I noticed a few days ago that unfortunately, Twemoji-Awesome is no longer maintained and updated (and thus misses fan favorites like 🤔 or 🧐)

I spent the afternoon building a plug-in replacement for twemoji-awesome called [twemoji-amazing](https://github.com/SebastianAigner/twemoji-amazing) that is up-to-date (and easy to keep up to date).

I have added it to the readme in place of Elle's original implementation and moved her project, marking it with "Unmaintained".

I also fixed the Twitter link for Elle, as it was pointing to a [nonexistent](https://twitter.com/ellekasai/status/531979044036698112) tweet.