### PR TITLE
Add transgender pride flag emoji

### DIFF
--- a/2/svg/1f3f3-fe0f-200d-26a7.svg
+++ b/2/svg/1f3f3-fe0f-200d-26a7.svg
@@ -1,0 +1,1 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 36 36"><path fill="#EEE" d="M0 15.4h36v5.2h-36z"/><path fill="#F5A9B8" d="M0 10.2h36v5.2h-36zM0 20.6h36v5.2h-36z"/><path fill="#5BCEFA" d="M32 5h-28c-2.21 0-4 1.79-4 4v1.2h36v-1.2c0-2.21-1.79-4-4-4zM4 31h28c2.21 0 4-1.79 4-4v-1.2h-36v1.2c0 2.21 1.79 4 4 4z"/></svg>


### PR DESCRIPTION
The latest version of WhatsApp includes the [transgender pride flag](https://en.wikipedia.org/wiki/Transgender_flags#Transgender_Pride_Flag) as [emoji ZWJ sequence](https://emojipedia.org/transgender-pride-flag/). It consists of U+1F3F3 (WAVING WHITE FLAG), U+FE0F (VARIATION SELECTOR-16), U+200D (ZERO WIDTH JOINER), U+26A7 (MALE WITH STROKE AND MALE AND FEMALE SIGN).

On WhatsApp it looks like this:
![](https://emojipedia-us.s3.dualstack.us-west-1.amazonaws.com/thumbs/160/whatsapp/186/transgender-pride-flag_1f3f3-fe0f-200d-26a7.png)

Several people on Twitter already [started using it](https://twitter.com/search?q=%F0%9F%8F%B3%EF%B8%8F%E2%80%8D%E2%9A%A7) since [2017](https://twitter.com/m_u_s_h_r_o_o_m/status/938876974151421953), so it would be great if Twemoji could add official support as well. Transgender activists are already requesting for this emoji for a long time, it was one of the most-requested emoji of [2018](https://blog.emojipedia.org/top-emoji-requests-2018/) and of [2017](https://blog.emojipedia.org/top-emoji-requests-2017/).

Several news articles have already been published about this new emoji in WhatsApp:
* [Transgender Pride Flag Emoji Hidden in Latest WhatsApp](https://blog.emojipedia.org/transgender-pride-flag-emoji-comes-to-whatsapp/) at Emojipedia
* [Hey Sis, the Trans Pride Flag Emoji Is Here](https://www.out.com/tech/2019/3/06/hey-sis-trans-pride-flag-emoji-here) at Out Magazine
* [A transgender Pride flag emoji exists—here’s how to get it](https://www.pinknews.co.uk/2019/03/06/transgender-pride-flag-emoji-how-get-it/) at PinkNews
* [There’s a secret WhatsApp trick which ‘lets you use a hidden transgender pride flag emoji in messages’](https://metro.co.uk/2019/03/06/secret-whatsapp-trick-lets-get-transgender-pride-flag-emoji-8836030/) at Metro