### PR TITLE
Added SRI to CDN link, bumped to 12.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The folks over at [MaxCDN](https://www.maxcdn.com) have graciously provided CDN 
 
 Use the following in the `<head>` tag of your HTML document(s):
 ```html
-<script src="https://twemoji.maxcdn.com/2/twemoji.min.js?12.0.0"></script>
+<script src="https://twemoji.maxcdn.com/2/twemoji.min.js?12.0.1" integrity="sha384-UM2aSky5TK+LGnb3eZ/K+LVxUWpoO1zhIRURk37uiM39vD0oshUZyKZEh3Rd/Gyl" crossorigin="anonymous"></script>
 ```
 
 ## Breaking changes in V2


### PR DESCRIPTION
Using subresource integrity hashes protects the client in the event that the remote source changes the contents of the file served unexpectedly, such as a vulnerability in a CDN.

From [MaxCDN Support](https://www.maxcdn.com/one/visual-glossary/subresource-integrity/):
> Subresource Integrity (SRI) is a security feature that instructs browsers to verify that resources fetched from third parties like CDNs have been delivered without any manipulation. SRI does this by comparing the hash values of the third-party-hosted resources to the values in the website’s HTML elements.

More information from Troy Hunt: https://www.troyhunt.com/protecting-your-embedded-content-with-subresource-integrity-sri/

I used https://www.srihash.org/ to generate the SHA384 hash on https://twemoji.maxcdn.com/2/twemoji.min.js?12.0.1 on 2019-05-23 8:15 PM EST.

I also bumped the version in the link to the current released version for consistency.