### PR TITLE
Adds Typescript definitions

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,41 @@
+interface TwemojiOptions {
+  /**
+   * Default: MaxCDN
+   */
+  base?: string;
+  /**
+   * Default: .png
+   */
+  ext?: string;
+  /**
+   * Default: emoji
+   */
+  className?: string;
+  /**
+   * Default: 72x72
+   */
+  size?: string | number;
+  /**
+   * To render with SVG use `folder: svg, ext: .svg`
+   */
+  folder?: string;
+  /**
+   * The function to invoke in order to generate image src(s).
+   */
+  callback?(icon: string, options: TwemojiOptions): void;
+  /**
+   * Default () => ({})
+   */
+  attributes?(): void;
+}
+
+const twemoji: {
+  convert: {
+    fromCodePoint(hexCodePoint: string): string;
+    toCodePoint(utf16surrogatePairs: string): string;
+  };
+  parse(node: HTMLElement | string, options?: TwemojiOptions): void;
+};
+
+export default twemoji;
+


### PR DESCRIPTION
Adds index.d.ts with Typescript typings for the library.

`index.d.ts` is the default definitions locations. If the file is in the project root and is named `index.d.ts` then there is no need to modify package.json.