### PR TITLE
The README file in this repo has a bad link - [404:NotFound] Emojiawesome

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,7 +224,7 @@ However, we consider the guide a bit onerous and as a project, will accept a men
 * [Twemoji Ruby](https://github.com/jollygoodcode/twemoji) by [@JollyGoodCode](https://twitter.com/jollygoodcode): Use Twemoji in Ruby.
 * [Twemoji for Pencil](https://github.com/nathanielw/Twemoji-for-Pencil) by [@Nathanielnw](https://twitter.com/nathanielnw): Use Twemoji in Pencil.
 * [FrwTwemoji - Twemoji in dotnet](http://github.frenchw.net/FrwTwemoji/) by [@FrenchW](https://twitter.com/frenchw): Use Twemoji in any dotnet project (C#, asp.net ...).
-* [Emojiawesome - Twemoji for Yellow](https://github.com/datenstrom/yellow-extensions/tree/master/features/emojiawesome) by [@datenstrom](https://github.com/datenstrom/): Use Twemoji on your website.
+* [Emojiawesome - Twemoji for Yellow](https://github.com/datenstrom/yellow-extensions/tree/master/source/emojiawesome) by [@datenstrom](https://github.com/datenstrom/): Use Twemoji on your website.
 * [EmojiPanel for Twitter](https://github.com/danbovey/EmojiPanel) by [@danielbovey](https://twitter.com/danielbovey/status/749580050274582528): Insert Twemoji into your tweets on twitter.com.
 * [Twitter Color Emoji font](https://github.com/eosrei/twemoji-color-font) by [@bderickson](https://twitter.com/bderickson): Use Twemoji as your system default font on Linux & OS X.
 * [Emojica](https://github.com/xoudini/emojica) by [@xoudini](https://twitter.com/xoudini): An iOS framework allowing you to replace all standard emoji in strings with Twemoji.


### PR DESCRIPTION
This should resolve issue #447

The README file in this repo has a bad link - [404:NotFound]

The markup version of the readme that is displayed for the main page in this repo contains the following link:

“Emojiawesome”
Status code [404:NotFound] - Link: https://github.com/datenstrom/yellow-extensions/tree/master/features/emojiawesome

I think it should be:
https://github.com/datenstrom/yellow-extensions/tree/master/source/emojiawesome
