### PR TITLE
Add index.d.ts to the npm package distribution #490

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,7 @@
     "universalify": "^0.1.2"
   },
   "files": [
-    "dist/twemoji*.js"
+    "dist/twemoji*.js",
+    "index.d.ts"
   ]
 }


### PR DESCRIPTION
As mentioned in #490, the `index.d.ts` file was not listed in the `files` section of the `package.json`.
This PR resolves this issue.