### PR TITLE
Use SPDX expression in package license field

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,10 +1,7 @@
 {
   "version": "13.1.0",
   "name": "twemoji",
-  "license": [
-    "MIT",
-    "CC-BY-4.0"
-  ],
+  "license": "(MIT AND CC-BY-4.0)",
   "description": "A Unicode 13.0 standard based way to implement emoji across all platforms.",
   "homepage": "https://github.com/twitter/twemoji",
   "keywords": [


### PR DESCRIPTION
We use an SPDX expression for the `license` field in `package.json` instead of the non-standard list of licenses. This is the standard format that [NPM recommends][1].

[1]: https://docs.npmjs.com/cli/v7/configuring-npm/package-json#license