### PR TITLE
Add Twemoji Utils to Community Projects

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ However, we consider the guide a bit onerous and as a project, will accept a men
 
 * [Twemoji Amazing](https://github.com/SebastianAigner/twemoji-amazing) by [@SebastianAigner](https://github.com/SebastianAigner): Use Twemoji using CSS classes (like [Font Awesome](http://fortawesome.github.io/Font-Awesome/)).
 * [Twemoji Ruby](https://github.com/jollygoodcode/twemoji) by [@JollyGoodCode](https://twitter.com/jollygoodcode): Use Twemoji in Ruby.
+* [Twemoji Utils](https://github.com/gustavwilliam/twemoji-utils) by [@gustavwilliam](https://github.com/gustavwilliam): Utilities for finding and downloading Twemoji source files.
 * [Twemoji for Pencil](https://github.com/nathanielw/Twemoji-for-Pencil) by [@Nathanielnw](https://twitter.com/nathanielnw): Use Twemoji in Pencil.
 * [FrwTwemoji - Twemoji in dotnet](http://github.frenchw.net/FrwTwemoji/) by [@FrenchW](https://twitter.com/frenchw): Use Twemoji in any dotnet project (C#, asp.net ...).
 * [Emojiawesome - Twemoji for Yellow](https://github.com/datenstrom/yellow-extensions/tree/master/source/emojiawesome) by [@datenstrom](https://github.com/datenstrom/): Use Twemoji on your website.


### PR DESCRIPTION
I've created a Vue-based website for easily finding and downloading Twemoji source files. This PR adds the project to the "Community Projects" section of the README.md.

The site is freely available at https://twemoji.godi.se (link to the [repo](https://github.com/gustavwilliam/twemoji-utils)), with attribution of the assets in the footer.