### PR TITLE
fix #532: Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier, and twemoji.parse return type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -29,12 +29,15 @@ declare interface TwemojiOptions {
   attributes?(): void;
 }
 
-declare const twemoji: {
+declare type twemoji = {
   convert: {
     fromCodePoint(hexCodePoint: string): string;
     toCodePoint(utf16surrogatePairs: string): string;
   };
-  parse(node: HTMLElement | string, options?: TwemojiOptions): string;
+  parse(node: HTMLElement | string, options?: TwemojiOptions): void;
 };
 
-export default twemoji;
+declare module "twemoji" {
+  const twemoji: twemoji;
+  export default twemoji;
+}

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,7 +29,7 @@ declare interface TwemojiOptions {
   attributes?(): void;
 }
 
-export const twemoji: {
+declare const twemoji: {
   convert: {
     fromCodePoint(hexCodePoint: string): string;
     toCodePoint(utf16surrogatePairs: string): string;

--- a/index.d.ts
+++ b/index.d.ts
@@ -29,7 +29,7 @@ declare interface TwemojiOptions {
   attributes?(): void;
 }
 
-declare type twemoji = {
+declare type Twemoji = {
   convert: {
     fromCodePoint(hexCodePoint: string): string;
     toCodePoint(utf16surrogatePairs: string): string;
@@ -37,7 +37,7 @@ declare type twemoji = {
   parse(node: HTMLElement | string, options?: TwemojiOptions): void;
 };
 
-declare module "twemoji" {
-  const twemoji: twemoji;
+declare module 'twemoji' {
+  const twemoji: Twemoji;
   export default twemoji;
 }

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,4 @@
-interface TwemojiOptions {
+declare interface TwemojiOptions {
   /**
    * Default: MaxCDN
    */
@@ -29,13 +29,12 @@ interface TwemojiOptions {
   attributes?(): void;
 }
 
-const twemoji: {
+export const twemoji: {
   convert: {
     fromCodePoint(hexCodePoint: string): string;
     toCodePoint(utf16surrogatePairs: string): string;
   };
-  parse(node: HTMLElement | string, options?: TwemojiOptions): void;
+  parse(node: HTMLElement | string, options?: TwemojiOptions): string;
 };
 
 export default twemoji;
-


### PR DESCRIPTION
- Fix Top-level declarations in .d.ts files must start with either a 'declare' or 'export' modifier reported on #532
- Fix Twemoji.parse return type to string instead of void
