### PR TITLE
fix: Type 'void' is not assignable to type 'string' on twemoji.parse typing.

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -34,7 +34,7 @@ declare type Twemoji = {
     fromCodePoint(hexCodePoint: string): string;
     toCodePoint(utf16surrogatePairs: string): string;
   };
-  parse(node: HTMLElement | string, options?: TwemojiOptions): void;
+  parse(node: HTMLElement | string, options?: TwemojiOptions): string;
 };
 
 declare module 'twemoji' {


### PR DESCRIPTION
Look like it was reverted in previous PR commits.
This fix the issue in that comment: https://github.com/twitter/twemoji/issues/532#issuecomment-1066699026

Once released, i can make a PR to update @joeattardi/emoji-button to use 14.0.2 and fix the issue #534

To reproduce the error that is fixed by this PR
1. git clone https://github.com/joeattardi/emoji-button.git
2. npm i 
3. npm i twemoji@14.0.1
4. npm run build
5. See error `emoji-button/src/lazyLoad.ts(40,5): semantic error TS2322: Type 'void' is not assignable to type 'string'.`
